### PR TITLE
Changed aspect ratio options names

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -80,7 +80,7 @@ public:
     static string   last_ram_file;
     static uint8_t  esp32rev;
     static bool     slog_on;
-    static bool     aspect_16_9;
+    static bool     aspect_letterbox;
     static uint8_t  lang;
     static bool     AY48;
     static bool     Issue2;    

--- a/include/Tape.h
+++ b/include/Tape.h
@@ -70,12 +70,11 @@ using namespace std;
 #define TAPE_PHASE_CSW 11
 #define TAPE_PHASE_GDB_PILOTSYNC 12
 #define TAPE_PHASE_GDB_DATA 13
-
 #define TAPE_PHASE_TAIL_GDB 14
 #define TAPE_PHASE_PAUSE_GDB 15
-#define TAPE_PHASE_TAIL_LEN_GDB 945
-
 #define TAPE_PHASE_END 16
+
+#define TAPE_PHASE_TAIL_LEN_GDB 945
 
 // Tape sync phases lenght in microseconds
 #define TAPE_SYNC_LEN 2168 // 620 microseconds for 2168 tStates (48K)
@@ -106,6 +105,12 @@ using namespace std;
 #define TAPE_BLK_PAUSELEN_RG 1113000UL // 318 ms.
 
 #define TAPE_LISTING_DIV 16
+
+#define FACTOR128K 1.013376779 // Pulse length compensation for Spectrum 128K
+// #define FACTOR128K 1 // Disable pulse length compensation for Spectrum 128K
+
+#define TAPEHIGH 0
+#define TAPELOW 1
 
 #define CHUNK_SIZE 1024
 struct TZXBlock {

--- a/include/messages.h
+++ b/include/messages.h
@@ -331,12 +331,12 @@ static const char *MENU_RENDER[2] = { MENU_RENDER_EN, MENU_RENDER_ES };
 
 #define MENU_ASPECT_EN \
     "Aspect Ratio\n"\
-    "4:3\t[4]\n"\
-    "16:9\t[1]\n"
+    "Stretch\t[4]\n"\
+    "Letterbox\t[1]\n"
 #define MENU_ASPECT_ES \
     "Rel. aspecto\n"\
-    "4:3\t[4]\n"\
-    "16:9\t[1]\n"
+    "Estirar\t[4]\n"\
+    "Lat. negros\t[1]\n"
 static const char *MENU_ASPECT[2] = { MENU_ASPECT_EN, MENU_ASPECT_ES };
 
 static const char *MENU_SCANLINES[2] = { "Scanlines\n", "Scanlines\n" };

--- a/include/messages.h
+++ b/include/messages.h
@@ -42,7 +42,7 @@ visit https://zxespectrum.speccy.org/contacto
 #define MSG_SAVE_CONFIG "Saving config file"
 #define MSG_VGA_INIT "Initializing VGA"
 
-#define EMU_VERSION "       v1.2 "
+#define EMU_VERSION "      v1.22 "
 
 // Error
 #define ERROR_TITLE "  !!!   ERROR - CLIVE MEDITATION   !!!  "
@@ -213,13 +213,13 @@ static const char *MENU_SNA[2] = { MENU_SNA_EN,MENU_SNA_ES };
 
 #define MENU_TAPE_EN \
     "Tape menu\n"\
-    "Select (TAP)\t(F5) >\n"\
+    "Select (TAP,TZX)\t(F5) >\n"\
     "Play/Stop\t(F6)  \n"\
     "Tape browser\t(F7)  \n"\
 	"Player mode\t>\n"
 #define MENU_TAPE_ES \
     "Casete\n"\
-    "Elegir (TAP)\t(F5) >\n"\
+    "Elegir (TAP,TZX)\t(F5) >\n"\
     "Play/Stop\t(F6)  \n"\
     "Navegador cinta\t(F7)  \n"\
 	"Modo reproductor\t>\n"

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -64,7 +64,7 @@ string   Config::ram_file = NO_RAM_FILE;
 string   Config::last_ram_file = NO_RAM_FILE;
 
 bool     Config::slog_on = false;
-bool     Config::aspect_16_9 = false;
+bool     Config::aspect_letterbox = false;
 uint8_t  Config::videomode = 0; // 0 -> SAFE VGA, 1 -> 50HZ VGA, 2 -> 50HZ CRT
 uint8_t  Config::esp32rev = 0;
 uint8_t  Config::lang = 0;
@@ -300,7 +300,7 @@ void Config::load() {
             str_data = (char *)malloc(required_size);
             nvs_get_str(handle, "asp169", str_data, &required_size);
             // printf("asp169:%s\n",str_data);
-            aspect_16_9 = strcmp(str_data, "false");
+            aspect_letterbox = strcmp(str_data, "false");
             free(str_data);
         }
 
@@ -607,7 +607,7 @@ void Config::save(string value) {
             nvs_set_str(handle,"sdstorage",FileUtils::MountPoint == MOUNT_POINT_SD ? "true" : "false");
 
         if((value=="asp169") || (value=="all"))
-            nvs_set_str(handle,"asp169",aspect_16_9 ? "true" : "false");
+            nvs_set_str(handle,"asp169",aspect_letterbox ? "true" : "false");
 
         if((value=="videomode") || (value=="all"))
             nvs_set_u8(handle,"videomode",Config::videomode);

--- a/src/ESPectrum.cpp
+++ b/src/ESPectrum.cpp
@@ -174,12 +174,12 @@ void ShowStartMsg() {
 
     OSD::drawOSD(false);
 
-    VIDEO::vga.fillRect(Config::aspect_16_9 ? 60 : 40,Config::aspect_16_9 ? 12 : 32,240,50,zxColor(0, 0));            
+    VIDEO::vga.fillRect(Config::aspect_letterbox ? 60 : 40,Config::aspect_letterbox ? 12 : 32,240,50,zxColor(0, 0));            
 
     // Decode Logo in EBF8 format
     uint8_t *logo = (uint8_t *)ESPectrum_logo;
-    int pos_x = Config::aspect_16_9 ? 86 : 66;
-    int pos_y = Config::aspect_16_9 ? 23 : 43;
+    int pos_x = Config::aspect_letterbox ? 86 : 66;
+    int pos_y = Config::aspect_letterbox ? 23 : 43;
     int logo_w = (logo[5] << 8) + logo[4]; // Get Width
     int logo_h = (logo[7] << 8) + logo[6]; // Get Height
     logo+=8; // Skip header
@@ -373,7 +373,7 @@ void ESPectrum::bootKeyboard() {
 
     if (i < 200) {
         Config::videomode = (s[0] == '1') ? 0 : (s[0] == '2') ? 1 : 2;
-        Config::aspect_16_9 = (s[1] == 'Q') ? false : true;
+        Config::aspect_letterbox = (s[1] == 'Q') ? false : true;
         Config::ram_file="none";
         Config::save();
         // printf("%s\n", s.c_str());
@@ -1634,7 +1634,7 @@ for(;;) {
 
                 if (VIDEO::OSD == 0) {
 
-                    if (Config::aspect_16_9) 
+                    if (Config::aspect_letterbox) 
                         VIDEO::Draw_OSD169 = VIDEO::MainScreen;
                     else
                         VIDEO::Draw_OSD43 = Z80Ops::isPentagon ? VIDEO::BottomBorder_Pentagon :  VIDEO::BottomBorder;

--- a/src/OSDFile.cpp
+++ b/src/OSDFile.cpp
@@ -75,16 +75,16 @@ string OSD::fileDialog(string &fdir, string title, uint8_t ftype, uint8_t mfcols
   
     // Position
     if (menu_level == 0) {
-        x = (Config::aspect_16_9 ? 24 : 4);
-        y = (Config::aspect_16_9 ? 4 : 4);
+        x = (Config::aspect_letterbox ? 24 : 4);
+        y = (Config::aspect_letterbox ? 4 : 4);
     } else {
-        x = (Config::aspect_16_9 ? 24 : 8) + (60 * menu_level);
+        x = (Config::aspect_letterbox ? 24 : 8) + (60 * menu_level);
         y = 8 + (16 * menu_level);
     }
 
     // Columns and Rows
     cols = mfcols;
-    mf_rows = mfrows + (Config::aspect_16_9 ? 0 : 1);
+    mf_rows = mfrows + (Config::aspect_letterbox ? 0 : 1);
 
     // printf("Focus: %d, Begin_row: %d, mf_rows: %d\n",(int) FileUtils::fileTypes[ftype].focus,(int) FileUtils::fileTypes[ftype].begin_row,(int) mf_rows);
     if (FileUtils::fileTypes[ftype].focus > mf_rows - 1) {
@@ -351,14 +351,14 @@ string OSD::fileDialog(string &fdir, string title, uint8_t ftype, uint8_t mfcols
 
                 unsigned int elem = FileUtils::fileTypes[ftype].fdMode ? fdSearchElements : elements;
                 if (elem) {
-                    menuAt(mfrows + (Config::aspect_16_9 ? 0 : 1), cols - (real_rows > virtual_rows ? 13 : 12));
+                    menuAt(mfrows + (Config::aspect_letterbox ? 0 : 1), cols - (real_rows > virtual_rows ? 13 : 12));
                     char elements_txt[13];
                     int nitem = (FileUtils::fileTypes[ftype].begin_row + FileUtils::fileTypes[ftype].focus ) - (4 + ndirs) + (fdir.length() == 1);
                     snprintf(elements_txt, sizeof(elements_txt), "%d/%d ", nitem > 0 ? nitem : 0 , elem);
                     VIDEO::vga.print(std::string(12 - strlen(elements_txt), ' ').c_str());
                     VIDEO::vga.print(elements_txt);
                 } else {
-                    menuAt(mfrows + (Config::aspect_16_9 ? 0 : 1), cols - 13);
+                    menuAt(mfrows + (Config::aspect_letterbox ? 0 : 1), cols - 13);
                     VIDEO::vga.print("             ");
                 }
 
@@ -435,7 +435,7 @@ string OSD::fileDialog(string &fdir, string title, uint8_t ftype, uint8_t mfcols
 
                             fdCursorFlash = 63;
 
-                            // menuAt(mfrows + (Config::aspect_16_9 ? 0 : 1), 1);
+                            // menuAt(mfrows + (Config::aspect_letterbox ? 0 : 1), 1);
                             // VIDEO::vga.setTextColor(zxColor(7, 1), zxColor(5, 0));
                             // VIDEO::vga.print(Config::lang ? "Busq: " : "Find: ");
                             // VIDEO::vga.print(FileUtils::fileTypes[ftype].fileSearch.c_str());
@@ -448,7 +448,7 @@ string OSD::fileDialog(string &fdir, string title, uint8_t ftype, uint8_t mfcols
 
                         } else {
 
-                            menuAt(mfrows + (Config::aspect_16_9 ? 0 : 1), 1);
+                            menuAt(mfrows + (Config::aspect_letterbox ? 0 : 1), 1);
                             VIDEO::vga.setTextColor(zxColor(7, 1), zxColor(5, 0));
                             VIDEO::vga.print("      " "          ");
 
@@ -633,7 +633,7 @@ string OSD::fileDialog(string &fdir, string title, uint8_t ftype, uint8_t mfcols
 
                 if ((++fdCursorFlash & 0xf) == 0) {
 
-                    menuAt(mfrows + (Config::aspect_16_9 ? 0 : 1), 1);
+                    menuAt(mfrows + (Config::aspect_letterbox ? 0 : 1), 1);
                     VIDEO::vga.setTextColor(zxColor(7, 1), zxColor(5, 0));
                     VIDEO::vga.print(Config::lang ? "Busq: " : "Find: ");
                     VIDEO::vga.print(FileUtils::fileTypes[ftype].fileSearch.c_str());

--- a/src/OSDMain.cpp
+++ b/src/OSDMain.cpp
@@ -199,7 +199,7 @@ void OSD::drawStats() {
 
     unsigned short x,y;
 
-    if (Config::aspect_16_9) {
+    if (Config::aspect_letterbox) {
         x = 156;
         y = 176;
     } else {
@@ -518,7 +518,7 @@ void OSD::do_OSD(fabgl::VirtualKey KeytoESP, bool CTRL) {
 
             if ((VIDEO::OSD & 0x03) > 2) {
                 if ((VIDEO::OSD & 0x04) == 0) {
-                    if (Config::aspect_16_9) 
+                    if (Config::aspect_letterbox) 
                         VIDEO::Draw_OSD169 = VIDEO::MainScreen;
                     else
                         VIDEO::Draw_OSD43 = Z80Ops::isPentagon ? VIDEO::BottomBorder_Pentagon :  VIDEO::BottomBorder;
@@ -527,7 +527,7 @@ void OSD::do_OSD(fabgl::VirtualKey KeytoESP, bool CTRL) {
             } else {
 
                 if ((VIDEO::OSD & 0x04) == 0) {
-                    if (Config::aspect_16_9) 
+                    if (Config::aspect_letterbox) 
                         VIDEO::Draw_OSD169 = VIDEO::MainScreen_OSD;
                     else
                         VIDEO::Draw_OSD43  = Z80Ops::isPentagon ? VIDEO::BottomBorder_OSD_Pentagon : VIDEO::BottomBorder_OSD;
@@ -556,7 +556,7 @@ void OSD::do_OSD(fabgl::VirtualKey KeytoESP, bool CTRL) {
 
             if (VIDEO::OSD == 0) {
 
-                if (Config::aspect_16_9) 
+                if (Config::aspect_letterbox) 
                     VIDEO::Draw_OSD169 = VIDEO::MainScreen_OSD;
                 else
                     VIDEO::Draw_OSD43  = Z80Ops::isPentagon ? VIDEO::BottomBorder_OSD_Pentagon : VIDEO::BottomBorder_OSD;
@@ -576,7 +576,7 @@ void OSD::do_OSD(fabgl::VirtualKey KeytoESP, bool CTRL) {
 
             unsigned short x,y;
 
-            if (Config::aspect_16_9) {
+            if (Config::aspect_letterbox) {
                 x = 156;
                 y = 180;
             } else {
@@ -597,7 +597,7 @@ void OSD::do_OSD(fabgl::VirtualKey KeytoESP, bool CTRL) {
 
             if (VIDEO::OSD == 0) {
 
-                if (Config::aspect_16_9) 
+                if (Config::aspect_letterbox) 
                     VIDEO::Draw_OSD169 = VIDEO::MainScreen_OSD;
                 else
                     VIDEO::Draw_OSD43  = Z80Ops::isPentagon ? VIDEO::BottomBorder_OSD_Pentagon : VIDEO::BottomBorder_OSD;
@@ -616,7 +616,7 @@ void OSD::do_OSD(fabgl::VirtualKey KeytoESP, bool CTRL) {
             }
 
             unsigned short x,y;
-            if (Config::aspect_16_9) {
+            if (Config::aspect_letterbox) {
                 x = 156;
                 y = 180;
             } else {
@@ -1392,7 +1392,7 @@ void OSD::do_OSD(fabgl::VirtualKey KeytoESP, bool CTRL) {
 
                                         // aspect ratio
                                         string asp_menu = MENU_ASPECT[Config::lang];
-                                        bool prev_asp = Config::aspect_16_9;
+                                        bool prev_asp = Config::aspect_letterbox;
                                         if (prev_asp) {
                                             asp_menu.replace(asp_menu.find("[4",0),2,"[ ");
                                             asp_menu.replace(asp_menu.find("[1",0),2,"[*");                        
@@ -1403,11 +1403,11 @@ void OSD::do_OSD(fabgl::VirtualKey KeytoESP, bool CTRL) {
                                         uint8_t opt2 = menuRun(asp_menu);
                                         if (opt2) {
                                             if (opt2 == 1)
-                                                Config::aspect_16_9 = false;
+                                                Config::aspect_letterbox = false;
                                             else
-                                                Config::aspect_16_9 = true;
+                                                Config::aspect_letterbox = true;
 
-                                            if (Config::aspect_16_9 != prev_asp) {
+                                            if (Config::aspect_letterbox != prev_asp) {
                                                 Config::ram_file = "none";
                                                 Config::save("asp169");
                                                 Config::save("ram");
@@ -1974,12 +1974,12 @@ void OSD::do_OSD(fabgl::VirtualKey KeytoESP, bool CTRL) {
                 // About
                 drawOSD(false);
                 
-                VIDEO::vga.fillRect(Config::aspect_16_9 ? 60 : 40,Config::aspect_16_9 ? 12 : 32,240,50,zxColor(0, 0));            
+                VIDEO::vga.fillRect(Config::aspect_letterbox ? 60 : 40,Config::aspect_letterbox ? 12 : 32,240,50,zxColor(0, 0));            
 
                 // Decode Logo in EBF8 format
                 uint8_t *logo = (uint8_t *)ESPectrum_logo;
-                int pos_x = Config::aspect_16_9 ? 86 : 66;
-                int pos_y = Config::aspect_16_9 ? 23 : 43;
+                int pos_x = Config::aspect_letterbox ? 86 : 66;
+                int pos_y = Config::aspect_letterbox ? 23 : 43;
                 int logo_w = (logo[5] << 8) + logo[4]; // Get Width
                 int logo_h = (logo[7] << 8) + logo[6]; // Get Height
                 logo+=8; // Skip header
@@ -1992,8 +1992,8 @@ void OSD::do_OSD(fabgl::VirtualKey KeytoESP, bool CTRL) {
                 VIDEO::vga.setTextColor(zxColor(7, 0), zxColor(1, 0));
                 // VIDEO::vga.print(Config::lang ? OSD_ABOUT1_ES : OSD_ABOUT1_EN);
                 
-                pos_x = Config::aspect_16_9 ? 66 : 46;
-                pos_y = Config::aspect_16_9 ? 68 : 88;            
+                pos_x = Config::aspect_letterbox ? 66 : 46;
+                pos_y = Config::aspect_letterbox ? 68 : 88;            
                 int osdRow = 0; int osdCol = 0;
                 int msgIndex = 0; int msgChar = 0;
                 int msgDelay = 0; int cursorBlink = 16; int nextChar = 0;
@@ -2035,7 +2035,7 @@ void OSD::do_OSD(fabgl::VirtualKey KeytoESP, bool CTRL) {
                     } else {
                         msgDelay--;
                         if (msgDelay==0) {
-                            VIDEO::vga.fillRect(Config::aspect_16_9 ? 60 : 40,Config::aspect_16_9 ? 64 : 84,240,114,zxColor(1, 0));
+                            VIDEO::vga.fillRect(Config::aspect_letterbox ? 60 : 40,Config::aspect_letterbox ? 64 : 84,240,114,zxColor(1, 0));
                             osdCol = 0;
                             osdRow  = 0;
                             msgChar = 0;

--- a/src/OSDMenu.cpp
+++ b/src/OSDMenu.cpp
@@ -187,10 +187,10 @@ unsigned short OSD::menuRun(string new_menu) {
 
     // Position
     if (menu_level == 0) {
-        x = (Config::aspect_16_9 ? 24 : 8);
+        x = (Config::aspect_letterbox ? 24 : 8);
         y = 8;
     } else {
-        x = (Config::aspect_16_9 ? 24 : 8) + (60 * menu_level);
+        x = (Config::aspect_letterbox ? 24 : 8) + (60 * menu_level);
         if (menu_saverect) {
             y += (8 + (8 * menu_prevopt));
             prev_y[menu_level] = y;
@@ -726,10 +726,10 @@ int OSD::menuTape(string title) {
 
     // Position
     if (menu_level == 0) {
-        x = (Config::aspect_16_9 ? 24 : 8);
+        x = (Config::aspect_letterbox ? 24 : 8);
         y = 8;
     } else {
-        x = (Config::aspect_16_9 ? 24 : 8) + (60 * menu_level);
+        x = (Config::aspect_letterbox ? 24 : 8) + (60 * menu_level);
         y = 8 + (16 * menu_level);
     }
 

--- a/src/Ports.cpp
+++ b/src/Ports.cpp
@@ -119,6 +119,7 @@ IRAM_ATTR uint8_t Ports::input(uint16_t address) {
                 data &= port[row];
         }
 
+        // // ** ESPectrum **
         // if (Tape::tapeStatus==TAPE_LOADING) {
         //     Tape::Read();
         //     bitWrite(data,6,Tape::tapeEarBit);
@@ -129,13 +130,12 @@ IRAM_ATTR uint8_t Ports::input(uint16_t address) {
 		// 		if (port254 & 0x10) data |= 0x40;
 		// }
 
+        // ** RVM **
         if (Tape::tapeStatus==TAPE_LOADING) Tape::Read();
-
         if ((Z80Ops::is48) && (Config::Issue2)) // Issue 2 behaviour only on Spectrum 48K
             if (port254 & 0x18) data |= 0x40;
         else
             if (port254 & 0x10) data |= 0x40;
-
         if (Tape::tapeEarBit) data ^= 0x40;
 
     } else {

--- a/src/Snapshot.cpp
+++ b/src/Snapshot.cpp
@@ -91,7 +91,7 @@ bool LoadSnapshot(string filename, string force_arch, string force_romset) {
 
     if (res && OSDprev) {
         VIDEO::OSD = OSDprev;
-        if (Config::aspect_16_9)
+        if (Config::aspect_letterbox)
             VIDEO::Draw_OSD169 = VIDEO::MainScreen_OSD;
         else
             VIDEO::Draw_OSD43  = Z80Ops::isPentagon ? VIDEO::BottomBorder_OSD_Pentagon : VIDEO::BottomBorder_OSD;

--- a/src/Tape.cpp
+++ b/src/Tape.cpp
@@ -260,7 +260,7 @@ void Tape::LoadTape(string mFile) {
 
                 if (OSDprev) {
                     VIDEO::OSD = OSDprev;
-                    if (Config::aspect_16_9)
+                    if (Config::aspect_letterbox)
                         VIDEO::Draw_OSD169 = VIDEO::MainScreen_OSD;
                     else
                         VIDEO::Draw_OSD43  = Z80Ops::isPentagon ? VIDEO::BottomBorder_OSD_Pentagon : VIDEO::BottomBorder_OSD;

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -568,7 +568,7 @@ IRAM_ATTR void VIDEO::MainScreen_Blank_Snow_Opcode(bool contended) {
 // ----------------------------------------------------------------------------------
 // Fast video emulation with no ULA cycle emulation and no snow effect support
 // ----------------------------------------------------------------------------------
-/*IRAM_ATTR*/ void VIDEO::MainScreen(unsigned int statestoadd, bool contended) {    
+IRAM_ATTR void VIDEO::MainScreen(unsigned int statestoadd, bool contended) {    
 
     if (contended) statestoadd += wait_st[CPU::tstates - tstateDraw];
 

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -272,7 +272,7 @@ void VIDEO::vgataskinit(void *unused) {
 
     if (Config::videomode == 1) {
 
-        Mode = 4 + (Config::arch == "48K" ? 0 : (Config::arch == "128K" ? 4 : 8)) + (Config::aspect_16_9 ? 2 : 0);
+        Mode = 4 + (Config::arch == "48K" ? 0 : (Config::arch == "128K" ? 4 : 8)) + (Config::aspect_letterbox ? 2 : 0);
 
         Mode += Config::scanlines;
 
@@ -281,7 +281,7 @@ void VIDEO::vgataskinit(void *unused) {
 
     } else {
 
-        Mode = 16 + (Config::arch == "48K" ? 0 : (Config::arch == "128K" ? 2 : 4)) + (Config::aspect_16_9 ? 1 : 0);
+        Mode = 16 + (Config::arch == "48K" ? 0 : (Config::arch == "128K" ? 2 : 4)) + (Config::aspect_letterbox ? 1 : 0);
         
         OSD::scrW = vidmodes[Mode][vmodeproperties::hRes];
         OSD::scrH = vidmodes[Mode][vmodeproperties::vRes] / vidmodes[Mode][vmodeproperties::vDiv];
@@ -319,7 +319,7 @@ void VIDEO::Init() {
         
     } else {
 
-        int Mode = Config::aspect_16_9 ? 2 : 0;
+        int Mode = Config::aspect_letterbox ? 2 : 0;
 
         Mode += Config::scanlines;
 
@@ -360,7 +360,7 @@ void VIDEO::Reset() {
     borderColor = 7;
     brd = border32[7];
 
-    is169 = Config::aspect_16_9 ? 1 : 0;
+    is169 = Config::aspect_letterbox ? 1 : 0;
 
     OSD = 0;
 


### PR DESCRIPTION
Updated aspect ratio options from "4:3" and "16:9", which referred to monitor settings, to "Stretch" and "Letterbox". This change provides clearer descriptions that reflect how content appears on screen, enhancing user understanding and usability.